### PR TITLE
feat: [15] Factory・Seeder 実装

### DIFF
--- a/app/Models/StaffProfile.php
+++ b/app/Models/StaffProfile.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class StaffProfile extends Model
 {
-    use SoftDeletes;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'user_id',

--- a/database/factories/StaffProfileFactory.php
+++ b/database/factories/StaffProfileFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -17,7 +18,7 @@ class StaffProfileFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => null,
+            'user_id' => User::factory(),
             'name' => fake('ja_JP')->name(),
             'date_of_birth' => fake()->dateTimeBetween('-40 years', '-18 years')->format('Y-m-d'),
             'is_student' => fake()->boolean(30),

--- a/database/factories/StaffProfileFactory.php
+++ b/database/factories/StaffProfileFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\StaffProfile>
+ */
+class StaffProfileFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => null,
+            'name' => fake('ja_JP')->name(),
+            'date_of_birth' => fake()->dateTimeBetween('-40 years', '-18 years')->format('Y-m-d'),
+            'is_student' => fake()->boolean(30),
+            'hourly_wage' => fake()->randomElement([1050, 1100, 1150, 1200, 1250]),
+            'memo' => null,
+            'max_consecutive_days' => null,
+            'max_hours_per_week' => null,
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,7 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Factories;
 
+use App\Models\Role;
+use App\Models\StaffProfile;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
@@ -11,14 +15,9 @@ use Illuminate\Support\Str;
  */
 class UserFactory extends Factory
 {
-    /**
-     * The current password being used by the factory.
-     */
     protected static ?string $password;
 
     /**
-     * Define the model's default state.
-     *
      * @return array<string, mixed>
      */
     public function definition(): array
@@ -31,13 +30,43 @@ class UserFactory extends Factory
         ];
     }
 
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
     public function unverified(): static
     {
-        return $this->state(fn (array $attributes) => [
+        return $this->state(fn (array $_) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    /**
+     * StaffProfile を一緒に生成する state。
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function withStaffProfile(array $attributes = []): static
+    {
+        return $this->afterCreating(function (\App\Models\User $user) use ($attributes) {
+            StaffProfile::factory()->create(array_merge(
+                ['user_id' => $user->id],
+                $attributes,
+            ));
+        });
+    }
+
+    /** Store Admin ロールを付与する state。 */
+    public function admin(): static
+    {
+        return $this->afterCreating(function (\App\Models\User $user) {
+            $role = Role::firstOrCreate(['name' => Role::ROLE_STORE_ADMIN]);
+            $user->roles()->syncWithoutDetaching([$role->id]);
+        });
+    }
+
+    /** Staff ロールを付与する state。 */
+    public function staff(): static
+    {
+        return $this->afterCreating(function (\App\Models\User $user) {
+            $role = Role::firstOrCreate(['name' => Role::ROLE_STAFF]);
+            $user->roles()->syncWithoutDetaching([$role->id]);
+        });
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,31 +1,33 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Database\Seeders;
 
 use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    use WithoutModelEvents;
-
-    /**
-     * Seed the application's database.
-     */
     public function run(): void
     {
         $this->call([
             RoleSeeder::class,
+            PositionSeeder::class,
         ]);
 
-        // User::factory(10)->create();
+        // 管理者ユーザー（重複実行に備えて firstOrCreate）
+        if (! \App\Models\User::where('email', 'admin@example.com')->exists()) {
+            User::factory()
+                ->admin()
+                ->withStaffProfile(['name' => '管理者'])
+                ->create(['email' => 'admin@example.com']);
+        }
 
-        $user = User::factory()->create([
-            'email' => 'test@example.com',
-        ]);
-        $user->staffProfile()->create([
-            'name' => 'テストユーザー',
-        ]);
+        // スタッフユーザー × 5
+        User::factory(5)
+            ->staff()
+            ->withStaffProfile()
+            ->create();
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Database\Seeders;
 
 use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
+    use WithoutModelEvents;
+
     public function run(): void
     {
         $this->call([
@@ -24,10 +27,15 @@ class DatabaseSeeder extends Seeder
                 ->create(['email' => 'admin@example.com']);
         }
 
-        // スタッフユーザー × 5
-        User::factory(5)
-            ->staff()
-            ->withStaffProfile()
-            ->create();
+        // スタッフユーザー × 5（重複実行に備えて exists チェック）
+        foreach (range(1, 5) as $i) {
+            $email = "staff{$i}@example.com";
+            if (! User::where('email', $email)->exists()) {
+                User::factory()
+                    ->staff()
+                    ->withStaffProfile(['name' => "スタッフ{$i}"])
+                    ->create(['email' => $email]);
+            }
+        }
     }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,7 +19,7 @@ class DatabaseSeeder extends Seeder
             PositionSeeder::class,
         ]);
 
-        // 管理者ユーザー（重複実行に備えて firstOrCreate）
+        // 管理者ユーザー（exists チェックで重複実行に対応）
         if (! \App\Models\User::where('email', 'admin@example.com')->exists()) {
             User::factory()
                 ->admin()

--- a/database/seeders/PositionSeeder.php
+++ b/database/seeders/PositionSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Position;
+use Illuminate\Database\Seeder;
+
+class PositionSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $positions = ['ホール', 'キッチン'];
+
+        foreach ($positions as $name) {
+            Position::firstOrCreate(['name' => $name]);
+        }
+    }
+}


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

UserFactory に state を追加し、PositionSeeder・DatabaseSeeder を整備してテスト用シードデータを投入できるようにした。

## 対象 変更内容

1. `database/factories/UserFactory.php` — `withStaffProfile()` / `admin()` / `staff()` state を追加
2. `database/factories/StaffProfileFactory.php` — 新規作成（日本語テストデータ定義）
3. `app/Models/StaffProfile.php` — `HasFactory` トレイトを追加
4. `database/seeders/PositionSeeder.php` — 新規作成（ホール・キッチンを投入）
5. `database/seeders/DatabaseSeeder.php` — Factory state を使った管理者・スタッフ生成に整備

## 変更の目的

- Factory state で User・StaffProfile・Role をまとめて生成できるようにするため
- `migrate:fresh --seed` 一発でテスト用の基本データが揃う状態にするため

## 動作確認

- [x] `migrate:fresh --seed` がエラーなく完了する
- [x] admin@example.com（Store Admin ロール付き）が生成される
- [x] スタッフユーザー 5 名と StaffProfile が生成される
- [x] `db:seed` を重複実行してもエラーにならない（冪等性）