### PR TITLE
fix: [16.1.1] メール認証フロー修正（AppServiceProvider URL）

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,7 +39,7 @@ class AppServiceProvider extends ServiceProvider
             $pathWithQuery = ($parsed['path'] ?? '') . '?' . ($parsed['query'] ?? '');
 
             $frontendUrl = config('app.frontend_url');
-            return "{$frontendUrl}/?verify_path=" . urlencode($pathWithQuery);
+            return "{$frontendUrl}/verify-email?verify_path=" . urlencode($pathWithQuery);
         });
 
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -38,12 +38,13 @@ class AppServiceProvider extends ServiceProvider
             $parsed = parse_url($signedUrl);
             $pathWithQuery = ($parsed['path'] ?? '') . '?' . ($parsed['query'] ?? '');
 
-            $frontendUrl = config('app.frontend_url');
+            $frontendUrl = rtrim(config('app.frontend_url'), '/');
             return "{$frontendUrl}/verify-email?verify_path=" . urlencode($pathWithQuery);
         });
 
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {
-            return config('app.frontend_url') . "/password-reset/$token?email={$notifiable->getEmailForPasswordReset()}";
+            $frontendUrl = rtrim(config('app.frontend_url'), '/');
+            return "{$frontendUrl}/password-reset/{$token}?email={$notifiable->getEmailForPasswordReset()}";
         });
     }
 }


### PR DESCRIPTION
<!-- GitHub Copilot へのレビュー指示 -->
<!-- @github-copilot レビューはすべて日本語で行ってください。指摘事項・提案・コメントを含むすべての出力を日本語で記述してください。 -->

## 概要

バックエンドが生成するメール認証リンクの URL を修正し、フロントエンドの `/verify-email` ルートに正しく到達できるようにする。

## 対象 変更内容

1. `AppServiceProvider.php` のメール認証URL生成を `/?verify_path=...` から `/verify-email?verify_path=...` に変更

## 変更の目的

- `/?verify_path=...` はフロントエンドの root index route により `/login` にリダイレクトされ `verify_path` が消失していた
- `/verify-email?verify_path=...` に変更することで Task 1（frontend）で追加したルートに正しく到達できる

## 動作確認

- [x] メール認証リンクが `{frontend_url}/verify-email?verify_path=...` 形式で生成される
- [x] リンクをクリックすると `/verify-email` ページが表示され認証が完了する