### PR TITLE
17.1 ShiftIndexTest の正常系レスポンス値検証を補強

### DIFF
--- a/app/Models/Position.php
+++ b/app/Models/Position.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Position extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'name',
     ];

--- a/app/Repositories/ShiftRepository.php
+++ b/app/Repositories/ShiftRepository.php
@@ -23,6 +23,7 @@ class ShiftRepository
 
         return Shift::with(['staffProfile'])
             ->whereBetween('start_at', [$start, $end])
+            ->orderBy('start_at')
             ->get();
     }
 }

--- a/database/factories/PositionFactory.php
+++ b/database/factories/PositionFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Position>
+ */
+class PositionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->jobTitle(),
+        ];
+    }
+}

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -141,6 +141,23 @@ class ShiftIndexTest extends TestCase
             ->assertJsonPath('data.0.end_at', '2026-05-05T17:00:00+00:00');
     }
 
+    public function test_all_shifts_within_period_are_returned(): void
+    {
+        $user = User::factory()->create();
+        $staffProfile = StaffProfile::factory()->create();
+
+        Shift::factory()->createMany([
+            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-01 09:00:00', 'end_at' => '2026-05-01 17:00:00'],
+            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-05 09:00:00', 'end_at' => '2026-05-05 17:00:00'],
+            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-15 09:00:00', 'end_at' => '2026-05-15 17:00:00'],
+        ]);
+
+        $this->actingAs($user)
+            ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
+            ->assertOk()
+            ->assertJsonCount(3, 'data');
+    }
+
     public function test_shifts_outside_period_are_not_returned(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -193,7 +193,7 @@ class ShiftIndexTest extends TestCase
 
     public function test_each_shift_returns_its_own_staff_profile(): void
     {
-        $user         = User::factory()->create();
+        $user          = User::factory()->create();
         $staffProfile1 = StaffProfile::factory()->create();
         $staffProfile2 = StaffProfile::factory()->create();
 
@@ -212,7 +212,9 @@ class ShiftIndexTest extends TestCase
             ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
             ->assertOk()
             ->assertJsonCount(2, 'data')
-            ->assertJsonFragment(['staff_id' => $staffProfile1->id, 'name' => $staffProfile1->name])
-            ->assertJsonFragment(['staff_id' => $staffProfile2->id, 'name' => $staffProfile2->name]);
+            ->assertJsonPath('data.0.staff_id', $staffProfile1->id)
+            ->assertJsonPath('data.0.staff_profile.name', $staffProfile1->name)
+            ->assertJsonPath('data.1.staff_id', $staffProfile2->id)
+            ->assertJsonPath('data.1.staff_profile.name', $staffProfile2->name);
     }
 }

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -134,11 +134,14 @@ class ShiftIndexTest extends TestCase
             'end_at'   => '2026-05-05 17:00:00',
         ]);
 
-        $this->actingAs($user)
+        $iso8601Pattern = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/';
+
+        $response = $this->actingAs($user)
             ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
-            ->assertOk()
-            ->assertJsonPath('data.0.start_at', '2026-05-05T09:00:00+00:00')
-            ->assertJsonPath('data.0.end_at', '2026-05-05T17:00:00+00:00');
+            ->assertOk();
+
+        $this->assertMatchesRegularExpression($iso8601Pattern, $response->json('data.0.start_at'));
+        $this->assertMatchesRegularExpression($iso8601Pattern, $response->json('data.0.end_at'));
     }
 
     public function test_all_shifts_within_period_are_returned(): void

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -99,6 +99,24 @@ class ShiftIndexTest extends TestCase
             ->assertJsonPath('data.0.staff_profile.name', $staffProfile->name);
     }
 
+    public function test_start_at_and_end_at_are_returned_in_iso8601_format(): void
+    {
+        $user = User::factory()->create();
+        $staffProfile = StaffProfile::factory()->create();
+
+        Shift::factory()->create([
+            'staff_id' => $staffProfile->id,
+            'start_at' => '2026-05-05 09:00:00',
+            'end_at'   => '2026-05-05 17:00:00',
+        ]);
+
+        $this->actingAs($user)
+            ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
+            ->assertOk()
+            ->assertJsonPath('data.0.start_at', '2026-05-05T09:00:00+00:00')
+            ->assertJsonPath('data.0.end_at', '2026-05-05T17:00:00+00:00');
+    }
+
     public function test_shifts_outside_period_are_not_returned(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -196,7 +196,7 @@ class ShiftIndexTest extends TestCase
 
     public function test_each_shift_returns_its_own_staff_profile(): void
     {
-        $user          = User::factory()->create();
+        $user = User::factory()->create();
         $staffProfile1 = StaffProfile::factory()->create();
         $staffProfile2 = StaffProfile::factory()->create();
 

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Shift;
 
+use App\Models\Position;
 use App\Models\Shift;
 use App\Models\StaffProfile;
 use App\Models\User;
@@ -97,6 +98,29 @@ class ShiftIndexTest extends TestCase
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.staff_id', $staffProfile->id)
             ->assertJsonPath('data.0.staff_profile.name', $staffProfile->name);
+    }
+
+    public function test_shift_fields_are_returned_with_correct_values(): void
+    {
+        $user = User::factory()->create();
+        $staffProfile = StaffProfile::factory()->create();
+        $position = Position::create(['name' => 'テストポジション']);
+
+        Shift::factory()->create([
+            'staff_id'    => $staffProfile->id,
+            'start_at'    => '2026-05-05 09:00:00',
+            'end_at'      => '2026-05-05 17:00:00',
+            'shift_state' => 'confirmed',
+            'position_id' => $position->id,
+            'memo'        => 'テスト用メモ',
+        ]);
+
+        $this->actingAs($user)
+            ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
+            ->assertOk()
+            ->assertJsonPath('data.0.shift_state', 'confirmed')
+            ->assertJsonPath('data.0.position_id', $position->id)
+            ->assertJsonPath('data.0.memo', 'テスト用メモ');
     }
 
     public function test_start_at_and_end_at_are_returned_in_iso8601_format(): void

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -158,6 +158,22 @@ class ShiftIndexTest extends TestCase
             ->assertJsonCount(3, 'data');
     }
 
+    public function test_shifts_on_boundary_dates_are_included(): void
+    {
+        $user = User::factory()->create();
+        $staffProfile = StaffProfile::factory()->create();
+
+        Shift::factory()->createMany([
+            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-01 00:00:00', 'end_at' => '2026-05-01 08:00:00'],
+            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-15 23:59:59', 'end_at' => '2026-05-15 23:59:59'],
+        ]);
+
+        $this->actingAs($user)
+            ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
+            ->assertOk()
+            ->assertJsonCount(2, 'data');
+    }
+
     public function test_shifts_outside_period_are_not_returned(): void
     {
         $user = User::factory()->create();

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -190,4 +190,29 @@ class ShiftIndexTest extends TestCase
             ->assertOk()
             ->assertJsonCount(0, 'data');
     }
+
+    public function test_each_shift_returns_its_own_staff_profile(): void
+    {
+        $user         = User::factory()->create();
+        $staffProfile1 = StaffProfile::factory()->create();
+        $staffProfile2 = StaffProfile::factory()->create();
+
+        Shift::factory()->create([
+            'staff_id' => $staffProfile1->id,
+            'start_at' => '2026-05-05 09:00:00',
+            'end_at'   => '2026-05-05 17:00:00',
+        ]);
+        Shift::factory()->create([
+            'staff_id' => $staffProfile2->id,
+            'start_at' => '2026-05-06 09:00:00',
+            'end_at'   => '2026-05-06 17:00:00',
+        ]);
+
+        $this->actingAs($user)
+            ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
+            ->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonFragment(['staff_id' => $staffProfile1->id, 'name' => $staffProfile1->name])
+            ->assertJsonFragment(['staff_id' => $staffProfile2->id, 'name' => $staffProfile2->name]);
+    }
 }

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -104,7 +104,7 @@ class ShiftIndexTest extends TestCase
     {
         $user = User::factory()->create();
         $staffProfile = StaffProfile::factory()->create();
-        $position = Position::create(['name' => 'テストポジション']);
+        $position = Position::factory()->create();
 
         Shift::factory()->create([
             'staff_id'    => $staffProfile->id,
@@ -165,7 +165,7 @@ class ShiftIndexTest extends TestCase
 
         Shift::factory()->createMany([
             ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-01 00:00:00', 'end_at' => '2026-05-01 08:00:00'],
-            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-15 23:59:59', 'end_at' => '2026-05-15 23:59:59'],
+            ['staff_id' => $staffProfile->id, 'start_at' => '2026-05-15 23:59:59', 'end_at' => '2026-05-16 07:00:00'],
         ]);
 
         $this->actingAs($user)


### PR DESCRIPTION
## 概要

GET /api/v1/shifts の正常系レスポンスに対して、値レベルの検証が不足していたため、5つのテストケースを追加しました。レビュー対応でアサーション方式の修正・Factory 統一・フォーマット検証の堅牢化も行いました。

## 変更内容

1. **[17.1.21] start_at / end_at の ISO 8601 フォーマット検証**
   ShiftResource の `toIso8601String()` 出力を `assertMatchesRegularExpression` で検証。タイムゾーン設定変更に対して堅牢なよう正規表現でフォーマット自体を検証しています（17.1.29 で改善）。

   - **対象メソッド**: `test_start_at_and_end_at_are_returned_in_iso8601_format`

2. **[17.1.22] shift_state / position_id / memo の値検証**
   各フィールドが設定値のままレスポンスに含まれることを検証するテストを追加。`position_id` に外部キー制約があるため `PositionFactory` を作成して `Position::factory()->create()` 経由で生成しています（17.1.28 で Factory に統一）。

   - **対象メソッド**: `test_shift_fields_are_returned_with_correct_values`

3. **[17.1.23] 複数シフトが全件返ること**
   1件のみでは件数欠落を検知できないため、`createMany` で3件作成し `assertJsonCount(3, 'data')` で検証するテストを追加。

   - **対象メソッド**: `test_all_shifts_within_period_are_returned`

4. **[17.1.24] from / to 境界日のシフトが含まれること**
   `whereBetween('start_at', [startOfDay, endOfDay])` の境界値が正しく含まれることを検証するテストを追加。

   - **対象メソッド**: `test_shifts_on_boundary_dates_are_included`

5. **[17.1.25 + 17.1.26] 複数スタッフで staff_profile が各シフトに正しく紐づくこと**
   1スタッフのテストだけでは Eager Loading の紐づき誤りを検知できないため、2スタッフ混在時のテストを追加。`assertJsonPath` によるインデックスを指定してテスト。順序を考慮して検証するため `ShiftRepository::findByPeriod` に `orderBy('start_at')` を追加しました。

   - **対象メソッド**: `test_each_shift_returns_its_own_staff_profile`
   - **対象ファイル**: `ShiftRepository::findByPeriod`（`orderBy` 追加）

## 動作確認

- [ ] `php artisan test --filter=ShiftIndexTest` で14件全テストがパスすること