### PR TITLE
feat: ShiftSeeder のダミーデータをランダム化

### DIFF
--- a/app/Http/Resources/ShiftResource.php
+++ b/app/Http/Resources/ShiftResource.php
@@ -17,7 +17,9 @@ class ShiftResource extends JsonResource
             'start_at'    => $this->start_at->toIso8601String(),
             'end_at'      => $this->end_at->toIso8601String(),
             'shift_state' => $this->shift_state,
-            'position_id' => $this->position_id,
+            'position'    => $this->whenLoaded('position', fn () => [
+                'name' => $this->position->name,
+            ]),
             'memo'        => $this->memo,
             'staff_profile' => $this->whenLoaded('staffProfile', fn () => [
                 'name' => $this->staffProfile->name,

--- a/app/Repositories/ShiftRepository.php
+++ b/app/Repositories/ShiftRepository.php
@@ -21,7 +21,7 @@ class ShiftRepository
         $start = Carbon::parse($from)->startOfDay();
         $end = Carbon::parse($to)->endOfDay();
 
-        return Shift::with(['staffProfile'])
+        return Shift::with(['staffProfile', 'position'])
             ->whereBetween('start_at', [$start, $end])
             ->orderBy('start_at')
             ->get();

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -25,7 +25,7 @@ class UserFactory extends Factory
         return [
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$password ??= Hash::make('shifty2026'),
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RoleSeeder::class,
             PositionSeeder::class,
+            ShiftSeeder::class,
         ]);
 
         // 管理者ユーザー（exists チェックで重複実行に対応）

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,7 +17,6 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RoleSeeder::class,
             PositionSeeder::class,
-            ShiftSeeder::class,
         ]);
 
         // 管理者ユーザー（exists チェックで重複実行に対応）
@@ -38,5 +37,9 @@ class DatabaseSeeder extends Seeder
                     ->create(['email' => $email]);
             }
         }
+
+        $this->call([
+            ShiftSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/ShiftSeeder.php
+++ b/database/seeders/ShiftSeeder.php
@@ -27,12 +27,12 @@ class ShiftSeeder extends Seeder
         $durations   = [6, 7, 8];
         $baseDate    = now()->startOfMonth();
 
-        foreach ($staffIds as $index => $staffId) {
+        foreach ($staffIds as $staffId) {
             // 各スタッフに当月1〜7日の日程でシフトを生成
             foreach (range(1, 7) as $day) {
                 $date        = $baseDate->copy()->addDays($day - 1);
-                $positionId  = $positions[$index % count($positions)];
-                $state       = $states[$day % count($states)];
+                $positionId  = $positions[array_rand($positions)];
+                $state       = $states[array_rand($states)];
                 $startHour   = $startHours[array_rand($startHours)];
                 $endHour     = $startHour + $durations[array_rand($durations)];
 

--- a/database/seeders/ShiftSeeder.php
+++ b/database/seeders/ShiftSeeder.php
@@ -23,6 +23,8 @@ class ShiftSeeder extends Seeder
 
         $positions   = [$hall->id, $kitchen->id];
         $states      = ['draft', 'confirmed'];
+        $startHours  = [8, 9, 10, 11, 12];
+        $durations   = [6, 7, 8];
         $baseDate    = now()->startOfMonth();
 
         foreach ($staffIds as $index => $staffId) {
@@ -31,14 +33,16 @@ class ShiftSeeder extends Seeder
                 $date        = $baseDate->copy()->addDays($day - 1);
                 $positionId  = $positions[$index % count($positions)];
                 $state       = $states[$day % count($states)];
+                $startHour   = $startHours[array_rand($startHours)];
+                $endHour     = $startHour + $durations[array_rand($durations)];
 
                 Shift::firstOrCreate(
                     [
                         'staff_id' => $staffId,
-                        'start_at' => $date->format('Y-m-d') . ' 09:00:00',
+                        'start_at' => $date->format('Y-m-d') . sprintf(' %02d:00:00', $startHour),
                     ],
                     [
-                        'end_at'      => $date->format('Y-m-d') . ' 17:00:00',
+                        'end_at'      => $date->format('Y-m-d') . sprintf(' %02d:00:00', $endHour),
                         'shift_state' => $state,
                         'position_id' => $positionId,
                         'memo'        => null,

--- a/database/seeders/ShiftSeeder.php
+++ b/database/seeders/ShiftSeeder.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Position;
+use App\Models\Shift;
+use App\Models\StaffProfile;
+use Illuminate\Database\Seeder;
+
+class ShiftSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $hall     = Position::where('name', 'ホール')->first();
+        $kitchen  = Position::where('name', 'キッチン')->first();
+        $staffIds = StaffProfile::pluck('id')->take(5);
+
+        if ($staffIds->isEmpty() || ! $hall || ! $kitchen) {
+            return;
+        }
+
+        $positions   = [$hall->id, $kitchen->id];
+        $states      = ['draft', 'confirmed'];
+        $baseDate    = now()->startOfMonth();
+
+        foreach ($staffIds as $index => $staffId) {
+            // 各スタッフに当月1〜7日の日程でシフトを生成
+            foreach (range(1, 7) as $day) {
+                $date        = $baseDate->copy()->addDays($day - 1);
+                $positionId  = $positions[$index % count($positions)];
+                $state       = $states[$day % count($states)];
+
+                Shift::firstOrCreate(
+                    [
+                        'staff_id' => $staffId,
+                        'start_at' => $date->format('Y-m-d') . ' 09:00:00',
+                    ],
+                    [
+                        'end_at'      => $date->format('Y-m-d') . ' 17:00:00',
+                        'shift_state' => $state,
+                        'position_id' => $positionId,
+                        'memo'        => null,
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/tests/Feature/Shift/ShiftIndexTest.php
+++ b/tests/Feature/Shift/ShiftIndexTest.php
@@ -119,7 +119,7 @@ class ShiftIndexTest extends TestCase
             ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
             ->assertOk()
             ->assertJsonPath('data.0.shift_state', 'confirmed')
-            ->assertJsonPath('data.0.position_id', $position->id)
+            ->assertJsonPath('data.0.position.name', $position->name)
             ->assertJsonPath('data.0.memo', 'テスト用メモ');
     }
 


### PR DESCRIPTION
## 概要

ShiftSeeder のポジション・状態が固定パターンで生成されていたため、ランダム選択に変更しました。また `migrate:fresh --seed` でシフトが生成されない順序バグを修正しました。

## 変更内容

1. **ShiftSeeder のランダム化**
   - ポジション割り当てを `index % count` から `array_rand()` に変更
   - shift_state を `day % count` から `array_rand()` に変更

2. **DatabaseSeeder の実行順序修正**
   - ShiftSeeder がスタッフ作成前に実行されてシフトが生成されなかった問題を修正
   - ShiftSeeder の呼び出しをスタッフユーザー作成後に移動

3. **ダミーパスワード変更**
   - UserFactory のデフォルトパスワードを `password` から `shifty2026` に変更

## 動作確認

- [x] `migrate:fresh --seed` でシフト35件が生成されること
- [x] ポジション・状態がランダムに割り振られていること