### PR TITLE
19.3 シフト更新 API を実装する

### DIFF
--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -36,7 +36,7 @@ class ShiftController extends Controller
 
     public function update(UpdateShiftRequest $request, Shift $shift): JsonResponse
     {
-        $updatedShift = $this->shiftCommandService->updateShift($shift, $request->validated());
+        $updatedShift = $this->shiftCommandService->update($shift, $request->validated());
 
         return $this->success(data: new ShiftResource($updatedShift));
     }

--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -6,7 +6,9 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\Shift\IndexShiftRequest;
 use App\Http\Requests\Shift\StoreShiftRequest;
+use App\Http\Requests\Shift\UpdateShiftRequest;
 use App\Http\Resources\ShiftResource;
+use App\Models\Shift;
 use App\Services\Shift\ShiftCommandService;
 use App\Services\Shift\ShiftQueryService;
 use Illuminate\Http\JsonResponse;
@@ -30,5 +32,12 @@ class ShiftController extends Controller
         $shift = $this->shiftCommandService->create($request->validated());
 
         return $this->success(data: new ShiftResource($shift), status: 201);
+    }
+
+    public function update(UpdateShiftRequest $request, Shift $shift): JsonResponse
+    {
+        $updatedShift = $this->shiftCommandService->updateShift($shift, $request->validated());
+
+        return $this->success(data: new ShiftResource($updatedShift));
     }
 }

--- a/app/Http/Requests/Shift/IndexShiftRequest.php
+++ b/app/Http/Requests/Shift/IndexShiftRequest.php
@@ -6,13 +6,9 @@ namespace App\Http\Requests\Shift;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+// authorize() 未定義 = 全許可（Laravel 11+ の FormRequest デフォルト動作）
 class IndexShiftRequest extends FormRequest
 {
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/Shift/StoreShiftRequest.php
+++ b/app/Http/Requests/Shift/StoreShiftRequest.php
@@ -14,11 +14,6 @@ class StoreShiftRequest extends FormRequest
      */
     public const MEMO_MAX_LENGTH = 1000;
 
-    public function authorize(): bool
-    {
-        return true;
-    }
-
     /**
      * @return array<string, array<int, mixed>>
      */

--- a/app/Http/Requests/Shift/StoreShiftRequest.php
+++ b/app/Http/Requests/Shift/StoreShiftRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Shift;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
+// authorize() 未定義 = 全許可（Laravel 11+ の FormRequest デフォルト動作）
 class StoreShiftRequest extends FormRequest
 {
     /**

--- a/app/Http/Requests/Shift/UpdateShiftRequest.php
+++ b/app/Http/Requests/Shift/UpdateShiftRequest.php
@@ -26,7 +26,7 @@ class UpdateShiftRequest extends FormRequest
             ],
             'end_at' => ['sometimes', 'date_format:Y-m-d H:i:s', 'after:start_at'],
             'break_start_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_end_at', 'after_or_equal:start_at', 'before:end_at'],
-            'break_end_at' => ['nullable', 'date_forma  t:Y-m-d H:i:s', 'required_with:break_start_at', 'after:break_start_at', 'before_or_equal:end_at'],
+            'break_end_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_start_at', 'after:break_start_at', 'before_or_equal:end_at'],
             'position_id' => ['nullable', 'integer', 'exists:positions,id'],
             'memo' => ['nullable', 'string', 'max:' . self::MEMO_MAX_LENGTH],
         ];

--- a/app/Http/Requests/Shift/UpdateShiftRequest.php
+++ b/app/Http/Requests/Shift/UpdateShiftRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Shift;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateShiftRequest extends FormRequest
+{
+    public const MEMO_MAX_LENGTH = 1000;
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'start_at' => [
+                'sometimes',
+                'date_format:Y-m-d H:i:s',
+                Rule::unique('shifts', 'start_at')->where(
+                    fn ($query) => $query->where('staff_id', $this->route('shift')->staff_id),
+                )->ignore($this->route('shift')),
+            ],
+            'end_at' => ['sometimes', 'date_format:Y-m-d H:i:s', 'after:start_at'],
+            'break_start_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_end_at', 'after_or_equal:start_at', 'before:end_at'],
+            'break_end_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_start_at', 'after:break_start_at', 'before_or_equal:end_at'],
+            'position_id' => ['nullable', 'integer', 'exists:positions,id'],
+            'memo' => ['nullable', 'string', 'max:' . self::MEMO_MAX_LENGTH],
+        ];
+    }
+}

--- a/app/Http/Requests/Shift/UpdateShiftRequest.php
+++ b/app/Http/Requests/Shift/UpdateShiftRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Shift;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
+// authorize() 未定義 = 全許可（Laravel 11+ の FormRequest デフォルト動作）
 class UpdateShiftRequest extends FormRequest
 {
     public const MEMO_MAX_LENGTH = 1000;

--- a/app/Http/Requests/Shift/UpdateShiftRequest.php
+++ b/app/Http/Requests/Shift/UpdateShiftRequest.php
@@ -26,7 +26,7 @@ class UpdateShiftRequest extends FormRequest
             ],
             'end_at' => ['sometimes', 'date_format:Y-m-d H:i:s', 'after:start_at'],
             'break_start_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_end_at', 'after_or_equal:start_at', 'before:end_at'],
-            'break_end_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_start_at', 'after:break_start_at', 'before_or_equal:end_at'],
+            'break_end_at' => ['nullable', 'date_forma  t:Y-m-d H:i:s', 'required_with:break_start_at', 'after:break_start_at', 'before_or_equal:end_at'],
             'position_id' => ['nullable', 'integer', 'exists:positions,id'],
             'memo' => ['nullable', 'string', 'max:' . self::MEMO_MAX_LENGTH],
         ];

--- a/app/Repositories/ShiftRepository.php
+++ b/app/Repositories/ShiftRepository.php
@@ -19,6 +19,16 @@ class ShiftRepository
     }
 
     /**
+     * @param  array<string, mixed>  $data
+     */
+    public function update(Shift $shift, array $data): Shift
+    {
+        $shift->update($data);
+
+        return $shift;
+    }
+
+    /**
      * 指定された日付期間（終日含む）のシフトを取得する
      *
      * @param  string  $from  引数は 'Y-m-d' 形式の日付

--- a/app/Repositories/ShiftRepository.php
+++ b/app/Repositories/ShiftRepository.php
@@ -23,6 +23,7 @@ class ShiftRepository
      */
     public function update(Shift $shift, array $data): Shift
     {
+        // DB トリガーや Observer で値が変わる場合は $shift->refresh() が必要
         $shift->update($data);
 
         return $shift;

--- a/app/Services/Shift/ShiftCommandService.php
+++ b/app/Services/Shift/ShiftCommandService.php
@@ -23,4 +23,14 @@ class ShiftCommandService
 
         return $this->shiftRepository->create($data);
     }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function updateShift(Shift $shift, array $data): Shift
+    {
+        $data['version'] = $shift->version + 1;
+
+        return $this->shiftRepository->update($shift, $data);
+    }
 }

--- a/app/Services/Shift/ShiftCommandService.php
+++ b/app/Services/Shift/ShiftCommandService.php
@@ -27,7 +27,7 @@ class ShiftCommandService
     /**
      * @param  array<string, mixed>  $data
      */
-    public function updateShift(Shift $shift, array $data): Shift
+    public function update(Shift $shift, array $data): Shift
     {
         $data['version'] = $shift->version + 1;
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -60,6 +60,9 @@ Route::prefix('v1')->group(function () {
 
             Route::post('/shifts', [ShiftController::class, 'store'])
                 ->name('api.v1.shifts.store');
+
+            Route::patch('/shifts/{shift}', [ShiftController::class, 'update'])
+                ->name('api.v1.shifts.update');
         });
     });
 });

--- a/tests/Feature/Shift/IndexShiftTest.php
+++ b/tests/Feature/Shift/IndexShiftTest.php
@@ -76,8 +76,9 @@ class IndexShiftTest extends TestCase
             ->getJson(self::ENDPOINT . '?from=2026-05-01&to=2026-05-15')
             ->assertOk()
             ->assertJson([
-                'status' => 'success',
-                'data'   => [],
+                'data'    => [],
+                'message' => null,
+                'errors'  => null,
             ]);
     }
 

--- a/tests/Feature/Shift/UpdateShiftTest.php
+++ b/tests/Feature/Shift/UpdateShiftTest.php
@@ -6,7 +6,6 @@ namespace Tests\Feature\Shift;
 
 use App\Models\Position;
 use App\Models\Shift;
-use App\Models\StaffProfile;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;

--- a/tests/Feature/Shift/UpdateShiftTest.php
+++ b/tests/Feature/Shift/UpdateShiftTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Shift;
+
+use App\Models\Position;
+use App\Models\Shift;
+use App\Models\StaffProfile;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UpdateShiftTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Shift $shift;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->shift = Shift::factory()->create([
+            'start_at' => '2026-08-01 09:00:00',
+            'end_at' => '2026-08-01 17:00:00',
+            'shift_state' => 'draft',
+            'version' => 1,
+            'memo' => null,
+        ]);
+    }
+
+    private function endpoint(int $shiftId): string
+    {
+        return "/api/v1/shifts/{$shiftId}";
+    }
+
+    public function test_valid_update_changes_field_and_preserves_others_with_version_increment(): void
+    {
+        $position = Position::factory()->create();
+
+        $this->actingAs($this->user)
+            ->patchJson($this->endpoint($this->shift->id), [
+                'memo' => '早番担当',
+                'position_id' => $position->id,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.memo', '早番担当');
+
+        $this->assertDatabaseHas('shifts', [
+            'id' => $this->shift->id,
+            'memo' => '早番担当',
+            'position_id' => $position->id,
+            'start_at' => '2026-08-01 09:00:00',
+            'end_at' => '2026-08-01 17:00:00',
+            'shift_state' => 'draft',
+            'version' => 2,
+        ]);
+    }
+
+    public function test_updating_start_at_to_same_value_does_not_trigger_duplicate_error(): void
+    {
+        $this->actingAs($this->user)
+            ->patchJson($this->endpoint($this->shift->id), [
+                'start_at' => '2026-08-01 09:00:00',
+            ])
+            ->assertOk();
+    }
+
+    public function test_different_staff_with_same_start_at_does_not_trigger_duplicate_error(): void
+    {
+        $otherShift = Shift::factory()->create([
+            'start_at' => '2026-08-01 10:00:00',
+            'end_at' => '2026-08-01 18:00:00',
+        ]);
+
+        $this->actingAs($this->user)
+            ->patchJson($this->endpoint($otherShift->id), [
+                'start_at' => '2026-08-01 09:00:00',
+            ])
+            ->assertOk();
+    }
+
+    public function test_nonexistent_shift_returns_404(): void
+    {
+        $this->actingAs($this->user)
+            ->patchJson($this->endpoint(99999), [
+                'memo' => 'not found',
+            ])
+            ->assertNotFound();
+    }
+
+    public function test_unauthenticated_request_returns_401(): void
+    {
+        $this->patchJson($this->endpoint($this->shift->id), [
+            'memo' => 'unauthorized',
+        ])
+            ->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## 概要

シフト管理機能の更新操作を実現するため、PATCH /api/v1/shifts/{shift} エンドポイントを CSR パターンで実装しました。

## 変更内容

1. **UpdateShiftRequest バリデーションクラス（19.3.1）**
   PATCH 部分更新に対応し各フィールドを `sometimes` に設定。

   - **UNIQUE 制約の自身除外**: `Rule::unique()->ignore()` で更新対象のシフト自身を重複チェックから除外
   - **StoreShiftRequest との独立**: DRY 基準（3箇所未満）により共通化せず独立クラスとして実装

2. **ルート登録（19.3.2）**
   API 設計書に基づき PATCH メソッドで登録。

   - **PATCH の採用理由**: 部分更新セマンティクスに適合。既存の shifts ルートと同じ verified ミドルウェアグループ内に配置

3. **Controller・Repository・Service（19.3.3〜19.3.5）**
   CSR パターンに従い各レイヤーの責務を分離。

   - **Controller**: UpdateShiftRequest で受け取り ShiftCommandService に委譲するのみ
   - **Repository**: Eloquent の `update()` をラップ
   - **Service**: `update()` メソッドで version を +1 インクリメント（楽観的ロック用）

4. **Feature テスト（19.3.6）**
   回帰テストとして機能させるため curl 手動検証から Feature テストに差し替え。

   - **StoreShiftTest との重複排除**: Update 固有の観点（部分更新で他フィールド維持・version +1・UNIQUE 自身除外）に絞り5本を実装
   - **IndexShiftTest 修正**: レスポンス形式の不一致（`status: "success"` → `data/message/errors`）を修正

5. **レビュー対応（19.3.7）**
   Claude・Copilot レビュー指摘への対応。

   - **メソッド命名統一**: ShiftCommandService の `updateShift()` → `update()` に統一（`create()` と命名パターンを合わせる）
   - **authorize() コメント追加**: Shift 系 FormRequest 3クラスに「authorize() 未定義 = 全許可」のコメントを追加。IndexShiftRequest は冗長な `authorize()` を削除
   - **ShiftRepository コメント追加**: DB トリガーや Observer 導入時に `refresh()` が必要になる旨のコメントを追加
   - **未使用 import 削除**: UpdateShiftTest から未使用の `StaffProfile` import を削除

## 今回スコープ外

- confirmed 状態のシフト更新ガード（管理者操作のため Phase1 では不要）
- ShiftResource への version フィールド追加（楽観的ロック用で内部管理のみ）
- Policy での認可チェック（タスク 20.1.5 で対応予定）
- PATCH 部分更新時の end_at バリデーション不整合（issue #34、19.4 で対応予定）

## 動作確認

- [x] UpdateShiftTest 5本すべてパス
- [x] IndexShiftTest 14本すべてパス（レスポンス形式修正含む）
- [x] StoreShiftTest 14本すべてパス（既存テストへの影響なし）