### PR TITLE
19.5 シフト削除 API を実装する

### DIFF
--- a/app/Exceptions/ApiExceptionRenderer.php
+++ b/app/Exceptions/ApiExceptionRenderer.php
@@ -34,7 +34,7 @@ final class ApiExceptionRenderer
                 $customMessage = $throwable->getMessage();
                 $message = $customMessage !== '' ? $customMessage : 'Validation failed';
             }
-            $errors = $this->normalizeValidationErrors($throwable->errors());
+            $errors = $throwable->errors();
         } elseif ($throwable instanceof AuthenticationException) {
             $status = 401;
             $message = 'Unauthenticated.';
@@ -74,21 +74,6 @@ final class ApiExceptionRenderer
             ),
             $status,
         );
-    }
-
-    /**
-     * @param  array<string, array<int, string>>  $errors
-     * @return array<string, array<int, string>>
-     */
-    private function normalizeValidationErrors(array $errors): array
-    {
-        $normalized = [];
-
-        foreach ($errors as $field => $messages) {
-            $normalized[(string) $field] = array_map(static fn (string $message): string => $message, $messages);
-        }
-
-        return $normalized;
     }
 
     private function shouldRenderAsJson(Request $request): bool

--- a/app/Exceptions/ApiExceptionRenderer.php
+++ b/app/Exceptions/ApiExceptionRenderer.php
@@ -63,7 +63,7 @@ final class ApiExceptionRenderer
     }
 
     /**
-     * @param array<string, string|array<int, string>>|null $errors
+     * @param  array<string, array<int, string>>|null  $errors
      */
     private function errorResponse(int $status, string $message, ?array $errors = null): Response
     {
@@ -77,7 +77,7 @@ final class ApiExceptionRenderer
     }
 
     /**
-     * @param array<string, mixed> $errors
+     * @param  array<string, array<int, string>>  $errors
      * @return array<string, array<int, string>>
      */
     private function normalizeValidationErrors(array $errors): array
@@ -85,12 +85,7 @@ final class ApiExceptionRenderer
         $normalized = [];
 
         foreach ($errors as $field => $messages) {
-            if (is_array($messages)) {
-                $normalized[(string) $field] = array_map(static fn(mixed $message): string => (string) $message, $messages);
-                continue;
-            }
-
-            $normalized[(string) $field] = [(string) $messages];
+            $normalized[(string) $field] = array_map(static fn (string $message): string => $message, $messages);
         }
 
         return $normalized;

--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -12,6 +12,7 @@ use App\Models\Shift;
 use App\Services\Shift\ShiftCommandService;
 use App\Services\Shift\ShiftQueryService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 
 class ShiftController extends Controller
 {
@@ -41,10 +42,10 @@ class ShiftController extends Controller
         return $this->success(data: new ShiftResource($updatedShift));
     }
 
-    public function destroy(Shift $shift): JsonResponse
+    public function destroy(Shift $shift): Response
     {
         $this->shiftCommandService->delete($shift);
 
-        return $this->success(status: 204);
+        return response()->noContent();
     }
 }

--- a/app/Http/Controllers/ShiftController.php
+++ b/app/Http/Controllers/ShiftController.php
@@ -40,4 +40,11 @@ class ShiftController extends Controller
 
         return $this->success(data: new ShiftResource($updatedShift));
     }
+
+    public function destroy(Shift $shift): JsonResponse
+    {
+        $this->shiftCommandService->delete($shift);
+
+        return $this->success(status: 204);
+    }
 }

--- a/app/Http/Requests/Shift/StoreShiftRequest.php
+++ b/app/Http/Requests/Shift/StoreShiftRequest.php
@@ -25,10 +25,12 @@ class StoreShiftRequest extends FormRequest
                 'required',
                 'integer',
                 'exists:staff_profiles,id',
-                // DB の UNIQUE (staff_id, start_at) はソフトデリート行も含むため、
-                // バリデーションでも削除済み行を除外せず DB の実態に合わせる
+                // DB の UNIQUE は生成カラム unique_delete_key により削除済み行を衝突対象から外すため、
+                // バリデーションでも削除済み行を除外して DB の実態に合わせる
                 Rule::unique('shifts', 'staff_id')->where(
-                    fn ($query) => $query->where('start_at', $this->input('start_at')),
+                    fn ($query) => $query
+                        ->where('start_at', $this->input('start_at'))
+                        ->whereNull('deleted_at'),
                 ),
             ],
             'start_at' => ['required', 'date_format:Y-m-d H:i:s'],

--- a/app/Http/Requests/Shift/UpdateShiftRequest.php
+++ b/app/Http/Requests/Shift/UpdateShiftRequest.php
@@ -21,15 +21,19 @@ class UpdateShiftRequest extends FormRequest
             'start_at' => [
                 'sometimes',
                 'date_format:Y-m-d H:i:s',
+                // DB の UNIQUE は生成カラム unique_delete_key により削除済み行を衝突対象から外すため、
+                // バリデーションでも削除済み行を除外して DB の実態に合わせる
                 Rule::unique('shifts', 'start_at')->where(
-                    fn ($query) => $query->where('staff_id', $this->route('shift')->staff_id),
+                    fn ($query) => $query
+                        ->where('staff_id', $this->route('shift')->staff_id)
+                        ->whereNull('deleted_at'),
                 )->ignore($this->route('shift')),
             ],
             'end_at' => ['sometimes', 'date_format:Y-m-d H:i:s', 'after:start_at'],
             'break_start_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_end_at', 'after_or_equal:start_at', 'before:end_at'],
             'break_end_at' => ['nullable', 'date_format:Y-m-d H:i:s', 'required_with:break_start_at', 'after:break_start_at', 'before_or_equal:end_at'],
             'position_id' => ['nullable', 'integer', 'exists:positions,id'],
-            'memo' => ['nullable', 'string', 'max:' . self::MEMO_MAX_LENGTH],
+            'memo' => ['nullable', 'string', 'max:'.self::MEMO_MAX_LENGTH],
         ];
     }
 }

--- a/app/Repositories/ShiftRepository.php
+++ b/app/Repositories/ShiftRepository.php
@@ -15,6 +15,7 @@ class ShiftRepository
      */
     public function create(array $data): Shift
     {
+        // インスタンス未作成のため静的メソッドで生成・保存を一括実行
         return Shift::create($data);
     }
 
@@ -27,6 +28,11 @@ class ShiftRepository
         $shift->update($data);
 
         return $shift;
+    }
+
+    public function delete(Shift $shift): void
+    {
+        $shift->delete();
     }
 
     /**

--- a/app/Services/Shift/ShiftCommandService.php
+++ b/app/Services/Shift/ShiftCommandService.php
@@ -33,4 +33,9 @@ class ShiftCommandService
 
         return $this->shiftRepository->update($shift, $data);
     }
+
+    public function delete(Shift $shift): void
+    {
+        $this->shiftRepository->delete($shift);
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3462,16 +3462,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
+                "reference": "d2d1aa8b35e072966c89bc0c66cf926e56767dc4",
                 "shasum": ""
             },
             "require": {
@@ -3493,12 +3493,12 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -3508,7 +3508,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.11-dev"
                 }
             },
             "autoload": {
@@ -3565,7 +3565,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-08-11T16:06:25+00:00"
         },
         {
             "name": "league/config",
@@ -4229,16 +4229,16 @@
         },
         {
             "name": "nette/schema",
-            "version": "v1.3.3",
+            "version": "v1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/schema.git",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004"
+                "reference": "c54350438cd6914616f790a49cb424605f421562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/2befc2f42d7c715fd9d95efc31b1081e5d765004",
-                "reference": "2befc2f42d7c715fd9d95efc31b1081e5d765004",
+                "url": "https://api.github.com/repos/nette/schema/zipball/c54350438cd6914616f790a49cb424605f421562",
+                "reference": "c54350438cd6914616f790a49cb424605f421562",
                 "shasum": ""
             },
             "require": {
@@ -4246,8 +4246,10 @@
                 "php": "8.1 - 8.5"
             },
             "require-dev": {
-                "nette/tester": "^2.5.2",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "nette/phpstan-rules": "^1.0",
+                "nette/tester": "^2.6",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1.39@stable",
                 "tracy/tracy": "^2.8"
             },
             "type": "library",
@@ -4288,22 +4290,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/schema/issues",
-                "source": "https://github.com/nette/schema/tree/v1.3.3"
+                "source": "https://github.com/nette/schema/tree/v1.3.6"
             },
-            "time": "2025-10-30T22:57:59+00:00"
+            "time": "2026-08-16T21:58:41+00:00"
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.1",
+            "version": "v4.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72"
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/c99059c0315591f1a0db7ad6002000288ab8dc72",
-                "reference": "c99059c0315591f1a0db7ad6002000288ab8dc72",
+                "url": "https://api.github.com/repos/nette/utils/zipball/b043439dbdf954e6c28b5ea7e34b0100f83165e0",
+                "reference": "b043439dbdf954e6c28b5ea7e34b0100f83165e0",
                 "shasum": ""
             },
             "require": {
@@ -4315,13 +4317,15 @@
             },
             "require-dev": {
                 "jetbrains/phpstorm-attributes": "^1.2",
+                "nette/phpstan-rules": "^1.0",
                 "nette/tester": "^2.5",
-                "phpstan/phpstan-nette": "^2.0@stable",
+                "phpstan/extension-installer": "^1.4@stable",
+                "phpstan/phpstan": "^2.1@stable",
                 "tracy/tracy": "^2.9"
             },
             "suggest": {
                 "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
+                "ext-iconv": "to use Strings::chr(), ord() and reverse()",
                 "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
                 "ext-json": "to use Nette\\Utils\\Json",
                 "ext-mbstring": "to use Strings::lower() etc...",
@@ -4377,9 +4381,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.1"
+                "source": "https://github.com/nette/utils/tree/v4.1.5"
             },
-            "time": "2025-12-22T12:14:32+00:00"
+            "time": "2026-07-17T23:02:45+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -5537,16 +5541,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -5559,7 +5563,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5584,7 +5588,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5596,11 +5600,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -6711,16 +6719,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -6771,7 +6779,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6791,7 +6799,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",

--- a/database/migrations/2026_08_21_000000_add_unique_delete_key_to_shifts_table.php
+++ b/database/migrations/2026_08_21_000000_add_unique_delete_key_to_shifts_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->dropForeign(['staff_id']);
+            $table->dropUnique(['staff_id', 'start_at']);
+        });
+
+        DB::statement("
+            ALTER TABLE shifts
+            ADD COLUMN unique_delete_key DATETIME
+            GENERATED ALWAYS AS (COALESCE(deleted_at, '9999-12-31 23:59:59')) STORED
+        ");
+
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->unique(['staff_id', 'start_at', 'unique_delete_key']);
+            $table->foreign('staff_id')->references('id')->on('staff_profiles')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->dropForeign(['staff_id']);
+            $table->dropUnique(['staff_id', 'start_at', 'unique_delete_key']);
+        });
+
+        DB::statement('ALTER TABLE shifts DROP COLUMN unique_delete_key');
+
+        Schema::table('shifts', function (Blueprint $table) {
+            $table->unique(['staff_id', 'start_at']);
+            $table->foreign('staff_id')->references('id')->on('staff_profiles')->onDelete('cascade');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -63,6 +63,9 @@ Route::prefix('v1')->group(function () {
 
             Route::patch('/shifts/{shift}', [ShiftController::class, 'update'])
                 ->name('api.v1.shifts.update');
+
+            Route::delete('/shifts/{shift}', [ShiftController::class, 'destroy'])
+                ->name('api.v1.shifts.destroy');
         });
     });
 });

--- a/tests/Feature/Exceptions/ApiExceptionResponseShapeTest.php
+++ b/tests/Feature/Exceptions/ApiExceptionResponseShapeTest.php
@@ -75,8 +75,6 @@ class ApiExceptionResponseShapeTest extends TestCase
             ->assertJsonPath('errors.email', ['The email field is required.']);
     }
 
-    /**
-     * @see \App\Exceptions\ApiExceptionRenderer::normalizeValidationErrors */
     public function test_validation_errors_are_always_normalized_to_arrays(): void
     {
         // 手動で文字列のメッセージを持つ ValidationException を投げる

--- a/tests/Feature/Shift/DestroyShiftTest.php
+++ b/tests/Feature/Shift/DestroyShiftTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Shift;
+
+use App\Models\Shift;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DestroyShiftTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Shift $shift;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->shift = Shift::factory()->create([
+            'shift_state' => 'draft',
+        ]);
+    }
+
+    private function endpoint(int $shiftId): string
+    {
+        return "/api/v1/shifts/{$shiftId}";
+    }
+
+    public function test_valid_delete_returns_204_and_soft_deletes_shift(): void
+    {
+        $this->actingAs($this->user)
+            ->deleteJson($this->endpoint($this->shift->id))
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('shifts', [
+            'id' => $this->shift->id,
+            'deleted_at' => null,
+        ])->assertDatabaseHas('shifts', [
+            'id' => $this->shift->id,
+        ]);
+    }
+
+    public function test_unauthenticated_request_returns_401(): void
+    {
+        $this->deleteJson($this->endpoint($this->shift->id))
+            ->assertUnauthorized();
+    }
+
+    public function test_nonexistent_shift_returns_404(): void
+    {
+        $this->actingAs($this->user)
+            ->deleteJson($this->endpoint(99999))
+            ->assertNotFound();
+    }
+
+    public function test_soft_deleted_shift_returns_404(): void
+    {
+        $this->shift->delete();
+
+        $this->actingAs($this->user)
+            ->deleteJson($this->endpoint($this->shift->id))
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/Shift/StoreShiftTest.php
+++ b/tests/Feature/Shift/StoreShiftTest.php
@@ -135,12 +135,10 @@ class StoreShiftTest extends TestCase
         $this->assertDatabaseCount('shifts', 1);
     }
 
-    public function test_duplicate_with_soft_deleted_shift_returns_422(): void
+    public function test_duplicate_with_soft_deleted_shift_returns_201(): void
     {
-        // DB の UNIQUE (staff_id, start_at) はソフトデリート行も対象のため、
-        // バリデーションを素通りさせると DB 例外で 500 になる。その防衛境界を検証する
-        // TODO: タスク19.3.5でUNIQUE制約をソフトデリート対応の生成カラムに変更した場合、
-        //       このテストの期待値は 422 → 201（再作成許可）に反転する想定
+        // DB の UNIQUE は生成カラム unique_delete_key により削除済み行を衝突対象から外すため、
+        // 削除済みシフトと同一の staff_id + start_at でも再作成できることを検証する
         $user = User::factory()->create();
         $staffProfile = StaffProfile::factory()->create();
 
@@ -157,8 +155,7 @@ class StoreShiftTest extends TestCase
                 'start_at' => '2026-08-01 09:00:00',
                 'end_at' => '2026-08-01 18:00:00',
             ])
-            ->assertUnprocessable()
-            ->assertJsonValidationErrors(['staff_id']);
+            ->assertCreated();
     }
 
     public function test_nonexistent_staff_id_returns_422(): void


### PR DESCRIPTION
## 概要

シフト管理機能の CRUD を完成させるため、シフト削除 API を実装しました。あわせて、ソフトデリート済みシフトが同一時間帯の再作成をブロックする問題を解消しました。

## 変更内容

1. **シフト削除エンドポイントの追加**
   `DELETE /api/v1/shifts/{shift}` を CSR パターンで追加（204 No Content）。Phase1 では confirmed ガードなし（管理者機能中心のため、確定済みシフトも削除可能とする判断）。

2. **UNIQUE 制約のソフトデリート対応**
   ソフトデリート済みシフトが DB に残り続けるため、同一 `staff_id + start_at` での再作成が UNIQUE 制約に引っかかって失敗する問題があった。MySQL は部分インデックスをサポートしないため、STORED 生成カラムを追加し「生存行は固定値、削除済み行は個別値」を返す方式で解消。

3. **バリデーションの整合性修正**
   `Rule::unique` は Eloquent の SoftDeletes グローバルスコープが効かず削除済み行も検索してしまうため、Store・Update 両方のバリデーションに `whereNull('deleted_at')` を追加。

4. **FeatureTest の追加・修正**
   DestroyShiftTest（4ケース）を新規追加。StoreShiftTest のソフトデリート再作成テストの期待値を反転（削除済み行との重複が許可されるため）。

5. **ApiExceptionRenderer の型シグネチャ修正**
   実際のデータフローに合わせて型を狭め、静的解析の警告を解消。恒等関数化した `normalizeValidationErrors` を削除。

## 動作確認

- [x] `php artisan test --filter=DestroyShiftTest` が全4テスト通過
- [x] `php artisan test --filter=StoreShiftTest` が全14テスト通過（ソフトデリート再作成テスト含む）
- [x] `php artisan test --filter=UpdateShiftTest` が全5テスト通過
- [x] `php artisan migrate` が正常に適用される