### PR TITLE
テスト失敗修正（status キー削除・パスワード不一致・ロケール設定）

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Str;
  */
 class UserFactory extends Factory
 {
+    public const DEFAULT_PASSWORD = 'shifty2026';
+
     protected static ?string $password;
 
     /**
@@ -25,7 +27,7 @@ class UserFactory extends Factory
         return [
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('shifty2026'),
+            'password' => static::$password ??= Hash::make(self::DEFAULT_PASSWORD),
             'remember_token' => Str::random(10),
         ];
     }

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
+use Database\Factories\UserFactory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -16,7 +17,7 @@ class AuthenticationTest extends TestCase
 
         $response = $this->post('/api/v1/login', [
             'email' => $user->email,
-            'password' => 'shifty2026',
+            'password' => UserFactory::DEFAULT_PASSWORD,
         ]);
 
         $this->assertAuthenticated();

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -16,7 +16,7 @@ class AuthenticationTest extends TestCase
 
         $response = $this->post('/api/v1/login', [
             'email' => $user->email,
-            'password' => 'password',
+            'password' => 'shifty2026',
         ]);
 
         $this->assertAuthenticated();

--- a/tests/Feature/Exceptions/ApiExceptionResponseShapeTest.php
+++ b/tests/Feature/Exceptions/ApiExceptionResponseShapeTest.php
@@ -31,16 +31,16 @@ class ApiExceptionResponseShapeTest extends TestCase
 
             Route::get('/422', function (): void {
                 throw ValidationException::withMessages([
-                    'email' => ['The email field is required.'],
+                    'email' => ['メールは必須項目です。'],
                 ]);
             });
 
             Route::get('/403', function (): void {
-                throw new AuthorizationException('Forbidden.');
+                throw new AuthorizationException('権限がありません。');
             });
 
             Route::get('/500', function (): void {
-                throw new RuntimeException('Unexpected error.');
+                throw new RuntimeException('予期しないエラーが発生しました。');
             });
 
             Route::get('/401', function (): string {
@@ -48,8 +48,8 @@ class ApiExceptionResponseShapeTest extends TestCase
             })->middleware('auth:sanctum');
             Route::get('/422-string-error', function (): void {
                 throw ValidationException::withMessages([
-                    'field1' => 'Single string error message',
-                    'field2' => ['Array message 1', 'Array message 2'],
+                    'field1' => '文字列エラーメッセージ',
+                    'field2' => ['配列メッセージ1', '配列メッセージ2'],
                 ]);
             });
         });
@@ -65,14 +65,14 @@ class ApiExceptionResponseShapeTest extends TestCase
         // 1. validate() 経由
         $response1 = $this->postJson('/api/v1/_test-exceptions/422-validate', []);
         $this->assertCommonErrorShape($response1, 422);
-        $response1->assertJsonPath('message', 'The email field is required.')
-            ->assertJsonPath('errors.email', ['The email field is required.']);
+        $response1->assertJsonPath('message', 'メールは必須項目です。')
+            ->assertJsonPath('errors.email', ['メールは必須項目です。']);
 
         // 2. FormRequest 経由
         $response2 = $this->postJson('/api/v1/_test-exceptions/422-form-request', []);
         $this->assertCommonErrorShape($response2, 422);
-        $response2->assertJsonPath('message', 'The email field is required.')
-            ->assertJsonPath('errors.email', ['The email field is required.']);
+        $response2->assertJsonPath('message', 'メールは必須項目です。')
+            ->assertJsonPath('errors.email', ['メールは必須項目です。']);
     }
 
     public function test_validation_errors_are_always_normalized_to_arrays(): void
@@ -81,16 +81,16 @@ class ApiExceptionResponseShapeTest extends TestCase
         $response = $this->getJson('/api/v1/_test-exceptions/422-string-error');
 
         $response->assertStatus(422)
-            ->assertJsonPath('message', 'Single string error message (and 2 more errors)')
-            ->assertJsonPath('errors.field1', ['Single string error message']) // 配列に正規化されていること
-            ->assertJsonPath('errors.field2', ['Array message 1', 'Array message 2']);
+            ->assertJsonPath('message', '文字列エラーメッセージ (その他、2エラーあり)')
+            ->assertJsonPath('errors.field1', ['文字列エラーメッセージ']) // 配列に正規化されていること
+            ->assertJsonPath('errors.field2', ['配列メッセージ1', '配列メッセージ2']);
     }
 
     public function test_custom_exception_messages_are_preserved_in_non_production(): void
     {
         $this->getJson('/api/v1/_test-exceptions/403')
             ->assertStatus(403)
-            ->assertJsonPath('message', 'Forbidden.');
+            ->assertJsonPath('message', '権限がありません。');
     }
 
     public function test_validation_and_authorization_messages_fall_back_to_standard_text_in_production(): void

--- a/tests/Feature/Exceptions/ApiExceptionResponseShapeTest.php
+++ b/tests/Feature/Exceptions/ApiExceptionResponseShapeTest.php
@@ -130,12 +130,10 @@ class ApiExceptionResponseShapeTest extends TestCase
     {
         $response->assertStatus($statusCode)
             ->assertJsonStructure([
-                'status',
                 'data',
                 'message',
                 'errors',
             ])
-            ->assertJsonPath('status', 'error')
             ->assertJsonPath('data', null);
     }
 

--- a/tests/Feature/Http/Responses/ApiResponseFormatTest.php
+++ b/tests/Feature/Http/Responses/ApiResponseFormatTest.php
@@ -14,7 +14,6 @@ class ApiResponseFormatTest extends TestCase
 
         $response->assertStatus(200)
             ->assertJson([
-                'status' => 'success',
                 'data' => [
                     'sample' => true,
                     'version' => 'v1',
@@ -30,7 +29,6 @@ class ApiResponseFormatTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJson([
-                'status' => 'error',
                 'data' => null,
                 'message' => 'validation failed',
                 'errors' => [

--- a/tests/Feature/Middleware/LocalOnlyTest.php
+++ b/tests/Feature/Middleware/LocalOnlyTest.php
@@ -22,12 +22,10 @@ class LocalOnlyTest extends TestCase
         $this->getJson('/api/v1/_debug/api-response/success')
             ->assertStatus(403)
             ->assertJsonStructure([
-                'status',
                 'data',
                 'message',
                 'errors',
             ])
-            ->assertJsonPath('status', 'error')
             ->assertJsonPath('data', null)
             ->assertJsonPath('message', 'Forbidden')
             ->assertJsonPath('errors', null);


### PR DESCRIPTION
## 概要

プロダクションコードの変更（ApiResponseStatus enum 削除、UserFactory パスワード変更、ロケール ja 化）にテストが追従しておらず11件が失敗していたため、テスト側を修正しました。

## 変更内容

1. **status キーの期待を削除（10件）**
   コミット 79edb21 で ApiResponseStatus enum が削除され、レスポンスから status フィールドが消えたが、テスト側が追従していなかった。ApiExceptionResponseShapeTest、ApiResponseFormatTest、LocalOnlyTest から status キーのアサーションを削除。

2. **AuthenticationTest のパスワード修正（1件）**
   UserFactory のデフォルトパスワードが `shifty2026` に変更済みだったが、テストは `password` を使用していたため認証が失敗していた。テスト側のパスワードを修正。

3. **バリデーションメッセージの日本語化**
   ロケール ja 化に伴い、テストの期待値を日本語メッセージに修正。テスト用ダミーエンドポイントの検証用メッセージも日本語に統一。

4. **UserFactory のデフォルトパスワードを定数化（レビュー対応）**
   テストと Factory でパスワードがハードコードで暗黙的に結合しており、再発リスクがあったため、`DEFAULT_PASSWORD` 定数を定義し両方から参照する形に統一。

## 動作確認

- [x] 全テスト70件パス（`php artisan test`）